### PR TITLE
Smaller release binaries

### DIFF
--- a/bin/cross-compile.sh
+++ b/bin/cross-compile.sh
@@ -35,4 +35,5 @@ go-bindata -o core/bindata.go -nometadata -pkg core tmp/
 # Cross compile
 gox \
 	-osarch="darwin/amd64 linux/amd64 windows/amd64" \
+	-ldflags="-s -w" \
 	-output="bin/{{.Dir}}_{{.OS}}_{{.Arch}}"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# myke examples
+
+Each folder has a `package_test.go` which contains CLI test cases with expected behavior:
+
+- `env` - environment variable behavior
+- `hooks` - hook behavior
+- `mixin` - mixing in one yml file into another
+- `retry` - retry behavior
+- `tag` - usage of tags to run tasks across multiple projects
+- `template` - command and file templating


### PR DESCRIPTION
- Tried upx as well, but macOS Sierra has broken all UPX compressed binaries, so avoiding it for now