### PR TITLE
Optimizations for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\goeuro\myke
+
+environment:
+  GOPATH: C:\gopath
+
+# Uncomment following line if you are willing to debug on the build machine.
+#init:
+#- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+install:
+- set PATH=%GOPATH%\bin;C:\go\bin;%WINDIR%;%WINDIR%\System32;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin
+- go version
+- go env
+- sh c:\gopath\src\github.com\goeuro\myke\bin\init.sh
+
+build_script:
+- gofmt -d -s -e . 2>&1 | tee -a fmt.out
+- test ! -s fmt.out
+- golint -set_exit_status .
+- go test -timeout 10s -v ./...
+

--- a/core/execution_default.go
+++ b/core/execution_default.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package core
+
+func executionShell() []string {
+	return []string{"sh", "-exc"}
+}
+
+func (e *Execution) beforeExecuteCmd(cmd string, env map[string]string) error {
+	return nil
+}

--- a/core/execution_windows.go
+++ b/core/execution_windows.go
@@ -1,0 +1,38 @@
+// +build windows
+
+package core
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var comSpec string
+
+func init() {
+	comSpec = os.Getenv("ComSpec")
+	if len(comSpec) > 0 {
+		return
+	}
+	winDir := os.Getenv("windir")
+	if len(winDir) > 0 {
+		comSpec = filepath.Join(winDir, "system32", "cmd.exe")
+	}
+	comSpec = "C:\\windows\\system32\\cmd.exe"
+	return
+}
+
+func executionShell() []string {
+	return []string{comSpec, "/C"}
+}
+
+func (e *Execution) beforeExecuteCmd(cmd string, env map[string]string) error {
+	// This will cause the same output like the sh -x on unix like systems.
+	proc := exec.Command(comSpec, "/C", "echo", "+", cmd)
+	proc.Dir = e.Project.Cwd
+	proc.Env = mapToSlice(env)
+	proc.Stdout = os.Stdout
+	proc.Stderr = os.Stderr
+	return proc.Run()
+}

--- a/core/execution_windows.go
+++ b/core/execution_windows.go
@@ -28,6 +28,9 @@ func executionShell() []string {
 }
 
 func (e *Execution) beforeExecuteCmd(cmd string, env map[string]string) error {
+	if len(e.Task.Shell) > 0 {
+		return nil
+	}
 	// This will cause the same output like the sh -x on unix like systems.
 	proc := exec.Command(comSpec, "/C", "echo", "+", cmd)
 	proc.Dir = e.Project.Cwd

--- a/core/util.go
+++ b/core/util.go
@@ -104,3 +104,13 @@ func retry(f func(attempt int) (retry bool, err error)) error {
 		attempt++
 	}
 }
+
+func mapToSlice(in map[string]string) []string {
+	list := make([]string, len(in))
+	i := 0
+	for k, v := range in {
+		list[i] = k + "=" + v
+		i++
+	}
+	return list
+}

--- a/core/util.go
+++ b/core/util.go
@@ -41,7 +41,8 @@ func OsEnv() map[string]string {
 	env := make(map[string]string)
 	for _, e := range os.Environ() {
 		pair := strings.SplitN(e, "=", 2)
-		if pair[0] != "PATH" {
+		// ToUpper is important here because on Windows this is case insensitive
+		if strings.ToUpper(pair[0]) != "PATH" {
 			// PATH is handled as a special case, so lets skip it
 			env[pair[0]] = pair[1]
 		}

--- a/examples/env/package_test.go
+++ b/examples/env/package_test.go
@@ -11,7 +11,7 @@ var tests = []TestTable{
 	{Arg: `file_default_local`, Out: `envvar from myke.env.local is value_from_myke.env.local`},
 	{Arg: `file_custom`, Out: `envvar from test.env is value_from_test.env`},
 	{Arg: `file_custom_local`, Out: `envvar from test.env.local is value_from_test.env.local`},
-	{Arg: `path`, Out: `PATH is [^:]+env/path_from_myke.env.local:[^:]+env/path_from_myke.env:[^:]+env/path_from_test.env.local:[^:]+env/path_from_test.env:[^:]+env/path_from_yml:[^:]+env/bin`},
+	{Arg: `path`, Out: `PATH is [^$PLS$]+env$PS$path_from_myke.env.local$PLS$[^$PLS$]+env$PS$path_from_myke.env$PLS$[^$PLS$]+env$PS$path_from_test.env.local$PLS$[^$PLS$]+env$PS$path_from_test.env$PLS$[^$PLS$]+env$PS$path_from_yml$PLS$[^$PLS$]+env$PS$bin`},
 }
 
 func Test(t *testing.T) {

--- a/examples/mixin/package_test.go
+++ b/examples/mixin/package_test.go
@@ -9,7 +9,7 @@ var tests = []TestTable{
 	{Arg: `task1`, Out: `parent says value_parent_1`},
 	{Arg: `task2`, Out: `(?s)parent says value_child_2.*?child says value_child_2`},
 	{Arg: `task3`, Out: `child says value_child_3`},
-	{Arg: `path`, Out: `PATH is [^:]+mixin/path_child:[^:]+mixin/bin:[^:]+mixin/parent/path_parent:[^:]+mixin/parent/bin`},
+	{Arg: `path`, Out: `PATH is [^$PLS$]+mixin$PS$path_child$PLS$[^$PLS$]+mixin$PS$bin$PLS$[^$PLS$]+mixin$PS$parent$PS$path_parent$PLS$[^$PLS$]+mixin$PS$parent$PS$bin`},
 }
 
 func Test(t *testing.T) {

--- a/examples/package_test.go
+++ b/examples/package_test.go
@@ -13,7 +13,7 @@ var tests = []TestTable{
 	{Arg: ``, Out: `(?m)^\s*retry\s*\|\s*\|\s*retry\s*$`},
 	{Arg: ``, Out: `(?m)^\s*tags1\s*\|\s*tagA, tagB\s*\|\s*tag\s*$`},
 	{Arg: ``, Out: `(?m)^\s*tags2\s*\|\s*tagB, tagC\s*\|\s*tag\s*$`},
-	{Arg: ``, Out: `(?m)^\s*template\s*\|\s*\|\s*args, file\s*$`},
+	{Arg: ``, Out: `(?m)^\s*template\s*\|\s*\|\s*args, envs, file\s*$`},
 }
 
 func Test(t *testing.T) {

--- a/examples/template/myke.yml
+++ b/examples/template/myke.yml
@@ -8,6 +8,9 @@ tasks:
   args:
     cmd: echo from={{.from|required}} to={{.to|default "something_to"}}
     desc: run as myke template/args[from=...,to=...]
+  envs:
+    cmd: echo PARAM1={{.PARAM2|required}} PARAM2={{.PARAM2|required}}
+    desc: run as myke template/envs
   file:
     cmd: myke --template template.tpl
     desc: run as myke template/file

--- a/examples/template/package_test.go
+++ b/examples/template/package_test.go
@@ -10,6 +10,7 @@ var tests = []TestTable{
 	{Arg: `args --from=a`, Out: `from=a to=something_to`},
 	{Arg: `args --from=a --to=b`, Out: `from=a to=b`},
 	{Arg: `args --from=a args --from=b`, Out: `(?s).*from=a to=something_to.*from=b to=something_to`},
+	{Arg: `envs`, Out: `(?s).*PARAM1=value2 PARAM2=value2`},
 	// Cannot invoke myke subcommand in a test
 	// {Arg:`file`, Out:`(?s)I am a template.*PARAM1=value1.*PARAM2=value2`},
 }

--- a/examples/util/test_util.go
+++ b/examples/util/test_util.go
@@ -4,6 +4,7 @@ package util
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/goeuro/myke/cmd"
 	"github.com/stretchr/testify/assert"
 	"io"
@@ -36,7 +37,10 @@ func runTest(t *testing.T, tt TestTable) {
 		return cmd.Exec(args)
 	})
 
-	if tt.Err == (err != nil) && assert.Regexp(t, tt.Out, actual) {
+	expectedOut := strings.Replace(tt.Out, "$PS$", fmt.Sprintf("\\%c", os.PathSeparator), -1)
+	expectedOut = strings.Replace(expectedOut, "$PLS$", fmt.Sprintf("\\%c", os.PathListSeparator), -1)
+
+	if tt.Err == (err != nil) && assert.Regexp(t, expectedOut, actual) {
 		t.Logf("myke(%s): passed", tt.Arg)
 	} else {
 		t.Errorf("myke(%s): failed %s", tt.Arg, err)


### PR DESCRIPTION
Changes that where made:
1. Bring myke go run with regular Windows environment on Windows systems
2. Add environment variable expansion in the way golang does (very close to sh) that it behaves on every operating system and/or distribution in the same way to be more "cross platform"
    Using ``os.Expand``
3. Added appveyor config to also enable tests to run on an Windows environment.
    This is very similar like Travis is. Just go to [ci.appveyor.com](https://ci.appveyor.com), login and grant access to repository. The appveyor configuration (see ``appveyor.yml``) enables the project to be build from this moment on without any trouble.
4. Some changes on the tests under ``examples`` to be runnable on Unix like systems and Windows.