### PR TITLE
Add verbosity level

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 type mykeOpts struct {
-	Verbose  []bool `short:"v" long:"verbose" description:"show verbose logs"`
+	Verbose  int    `short:"v" long:"verbose" description:"verbosity level, 0 (nothing) to 5 (everything)" default:"3"`
 	File     string `short:"f" long:"file" description:"yml file to load" default:"myke.yml"`
 	DryRun   bool   `short:"n" long:"dry-run" description:"print tasks without running them"`
 	Version  bool   `long:"version" description:"print myke version"`
@@ -52,10 +52,15 @@ func Exec(_args []string) error {
 // Action runs using parsed args
 func Action(opts *mykeOpts, tasks []string) error {
 	log.SetHandler(&cli.Handler{Writer: opts.Writer, Padding: 0})
-	switch len(opts.Verbose) {
-	case 0:
+	if opts.Verbose <= 0 {
+		log.SetLevel(log.FatalLevel)
+	} else if opts.Verbose == 1 {
+		log.SetLevel(log.ErrorLevel)
+	} else if opts.Verbose == 2 {
+		log.SetLevel(log.WarnLevel)
+	} else if opts.Verbose == 3 {
 		log.SetLevel(log.InfoLevel)
-	default:
+	} else {
 		log.SetLevel(log.DebugLevel)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 type mykeOpts struct {
-	Verbose  int    `short:"v" long:"verbose" description:"verbosity level, 0 (nothing) to 5 (everything)" default:"3"`
+	Verbose  int    `short:"v" long:"verbose" description:"verbosity level, 3=info, <0=nothing, >5=everything" default:"3"`
 	File     string `short:"f" long:"file" description:"yml file to load" default:"myke.yml"`
 	DryRun   bool   `short:"n" long:"dry-run" description:"print tasks without running them"`
 	Version  bool   `long:"version" description:"print myke version"`

--- a/examples/retry/package_test.go
+++ b/examples/retry/package_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 var tests = []TestTable{
-	{Arg: `-vv retry`, Out: `(?s)false.*retry/retry: Failed, Retrying 1/5 in 10ms.*false.*Retrying 2/5.*false.*Retrying 3/5.*false.*Retrying 4/5.*false.*retry/retry: Failed`, Err: true},
+	{Arg: `-v=5 retry`, Out: `(?s)false.*retry/retry: Failed, Retrying 1/5 in 10ms.*false.*Retrying 2/5.*false.*Retrying 3/5.*false.*Retrying 4/5.*false.*retry/retry: Failed`, Err: true},
 	{Arg: `retry`, Out: `(Retrying \d+){0}`, Err: true},
 }
 

--- a/examples/retry/package_test.go
+++ b/examples/retry/package_test.go
@@ -6,8 +6,12 @@ import (
 )
 
 var tests = []TestTable{
-	{Arg: `-v=5 retry`, Out: `(?s)false.*retry/retry: Failed, Retrying 1/5 in 10ms.*false.*Retrying 2/5.*false.*Retrying 3/5.*false.*Retrying 4/5.*false.*retry/retry: Failed`, Err: true},
+	{Arg: `-v=0 retry`, Out: `(Running){0}`, Err: true},
+	{Arg: `-v=0 retry`, Out: `(Failed){0}`, Err: true},
+	{Arg: `-v=0 retry`, Out: `(Running){0}`, Err: true},
+	{Arg: `-v=1 retry`, Out: `Failed`, Err: true},
 	{Arg: `retry`, Out: `(Retrying \d+){0}`, Err: true},
+	{Arg: `-v=5 retry`, Out: `(?s)false.*retry/retry: Failed, Retrying 1/5 in 10ms.*false.*Retrying 2/5.*false.*Retrying 3/5.*false.*Retrying 4/5.*false.*retry/retry: Failed`, Err: true},
 }
 
 func Test(t *testing.T) {

--- a/examples/template/package_test.go
+++ b/examples/template/package_test.go
@@ -11,8 +11,7 @@ var tests = []TestTable{
 	{Arg: `args --from=a --to=b`, Out: `from=a to=b`},
 	{Arg: `args --from=a args --from=b`, Out: `(?s).*from=a to=something_to.*from=b to=something_to`},
 	{Arg: `envs`, Out: `(?s).*PARAM1=value2 PARAM2=value2`},
-	// Cannot invoke myke subcommand in a test
-	// {Arg:`file`, Out:`(?s)I am a template.*PARAM1=value1.*PARAM2=value2`},
+	{Arg: `--template template.tpl`, Out: `(?s)^I am a template.*TEST=TEST.*`},
 }
 
 func Test(t *testing.T) {

--- a/examples/template/template.tpl
+++ b/examples/template/template.tpl
@@ -1,3 +1,4 @@
 I am a template
-PARAM1={{.PARAM1}}
-PARAM2={{.PARAM2}}
+TEST={{ "test" | upper }}
+PARAM1={{ .PARAM1 }}
+PARAM2={{ .PARAM2 }}

--- a/examples/util/test_util.go
+++ b/examples/util/test_util.go
@@ -36,7 +36,11 @@ func runTest(t *testing.T, tt TestTable) {
 		args := strings.Split(tt.Arg, " ")
 		return cmd.Exec(args)
 	})
-	actual = fmt.Sprintf("%v %v", actual, err)
+
+	if err != nil {
+		// add error message to output for validating error messages
+		actual = fmt.Sprintf("%v %v", actual, err)
+	}
 
 	expectedOut := strings.Replace(tt.Out, "$PS$", "/", -1)
 	expectedOut = strings.Replace(expectedOut, "$PLS$", ":", -1)


### PR DESCRIPTION
- Syntax: `-v=log level, <0=nothing, >5=everything, default=3 (info)`
- Compatible with kubernetes, and independent of logging library
- Single flag instead of two (like -v for verbose and -q for quiet)
- Added one test, but need to add more
- Fixes #83 