### PR TITLE
Expose Workspace cwd as environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Explore the self documenting `examples` folder.
 * same is done for every mixin that the yml uses
   * So, if you mixin `<some-other-folder>/myke.yml`, then that yml's `cwd/bin` is also added to the PATH, that yml's env/env_files/env_files.local are also loaded, and so on
 * shell exported environment variables take precedence
-* additional variables: `$MYKE_PROJECT`, `$MYKE_TASK`, `$MYKE_CWD` are always set
+* additional variables: `$MYKE_WS_CWD` `$MYKE_PROJECT`, `$MYKE_TASK`, `$MYKE_CWD` are always set
   * `$myke` is set to full path of myke itself to easily nest myke calls (e.g. `$myke do_something` will become `myke.exe do_something` in windows)
 * command is templated using golang text/template and sprig
   * environment and task arguments are passed in as variables

--- a/core/execution.go
+++ b/core/execution.go
@@ -119,6 +119,7 @@ func (e *Execution) env() map[string]string {
 	myke, _ := osext.Executable()
 	extraEnv := map[string]string{
 		"myke":         myke,
+		"MYKE_WS_CWD":  e.Workspace.Cwd,
 		"MYKE_PROJECT": e.Project.Name,
 		"MYKE_TASK":    e.Task.Name,
 		"MYKE_CWD":     e.Project.Cwd,

--- a/examples/env/myke.yml
+++ b/examples/env/myke.yml
@@ -31,3 +31,13 @@ tasks:
     cmd: echo envvar from test.env.local is $KEY_ENVFILE_LOCAL
   path:
     cmd: echo PATH is $PATH
+  myke_env_myke:
+    cmd: echo $myke
+  myke_env_ws_cwd:
+    cmd: echo $MYKE_WS_CWD
+  myke_env_project:
+    cmd: echo $MYKE_PROJECT
+  myke_env_task:
+    cmd: echo $MYKE_TASK
+  myke_env_cwd:
+    cmd: echo $MYKE_CWD

--- a/examples/env/package_test.go
+++ b/examples/env/package_test.go
@@ -12,6 +12,11 @@ var tests = []TestTable{
 	{Arg: `file_custom`, Out: `envvar from test.env is value_from_test.env`},
 	{Arg: `file_custom_local`, Out: `envvar from test.env.local is value_from_test.env.local`},
 	{Arg: `path`, Out: `PATH is [^$PLS$]+env$PS$path_from_myke.env.local$PLS$[^$PLS$]+env$PS$path_from_myke.env$PLS$[^$PLS$]+env$PS$path_from_test.env.local$PLS$[^$PLS$]+env$PS$path_from_test.env$PLS$[^$PLS$]+env$PS$path_from_yml$PLS$[^$PLS$]+env$PS$bin`},
+	{Arg: `myke_env_myke`, Out: `myke`},
+	{Arg: `myke_env_ws_cwd`, Out: `[/\\]examples[/\\]env`},
+	{Arg: `myke_env_project`, Out: `env`},
+	{Arg: `myke_env_task`, Out: `myke_env_task`},
+	{Arg: `myke_env_cwd`, Out: `[/\\]examples[/\\]env`},
 }
 
 func Test(t *testing.T) {

--- a/examples/package_test.go
+++ b/examples/package_test.go
@@ -7,7 +7,7 @@ import (
 
 var tests = []TestTable{
 	{Arg: ``, Out: `(?m)^\s*PROJECT\s*\|\s*TAGS\s*\|\s*TASKS\s*$`},
-	{Arg: ``, Out: `(?m)^\s*env\s*\|\s*\|\s*file_custom, file_custom_local, file_default, file_default_local, path, yml\s*$`},
+	{Arg: ``, Out: `(?m)^\s*env\s*\|\s*\|\s*file_custom, file_custom_local, file_default, file_default_local, myke_env_cwd, myke_env_myke, myke_env_project, myke_env_task, myke_env_ws_cwd, path, yml\s*$`},
 	{Arg: ``, Out: `(?m)^\s*hooks\s*\|\s*\|\s*after, before, error\s*$`},
 	{Arg: ``, Out: `(?m)^\s*mixin\s*\|\s*\|\s*path, task1, task2, task3\s*$`},
 	{Arg: ``, Out: `(?m)^\s*retry\s*\|\s*\|\s*retry\s*$`},


### PR DESCRIPTION
Adds new myke environment variable `MYKE_WS_CWD` to provide access the
base path of the workspace. This will allow users to reference the
workspace cwd to within a task to indicate the location of a file or
directory starting from base of workspace.