### PR TITLE
Fix environment variable late interpolation

### DIFF
--- a/examples/package_test.go
+++ b/examples/package_test.go
@@ -14,6 +14,7 @@ var tests = []TestTable{
 	{Arg: ``, Out: `(?m)^\s*tags1\s*\|\s*tagA, tagB\s*\|\s*tag\s*$`},
 	{Arg: ``, Out: `(?m)^\s*tags2\s*\|\s*tagB, tagC\s*\|\s*tag\s*$`},
 	{Arg: ``, Out: `(?m)^\s*template\s*\|\s*\|\s*args, envs, file\s*$`},
+	{Arg: ``, Out: `(?m)^\s*shell\s*\|\s*\|\s*echo, error, interpolate, shell, subshell\s*$`},
 	{Arg: `--help`, Out: `(?s).*Usage.*myke options.*`},
 	{Arg: `--version`, Out: `.*myke version.*`},
 	{Arg: `--license`, Out: `.*OPEN SOURCE LICENSES.*`},

--- a/examples/shell/myke.yml
+++ b/examples/shell/myke.yml
@@ -11,6 +11,6 @@ tasks:
   echo:
     cmd: echo
   interpolate:
-    cmd:
+    cmd: |-
       foo=value_from_task
       echo $(echo envvar from subshell is $foo)

--- a/examples/shell/myke.yml
+++ b/examples/shell/myke.yml
@@ -10,3 +10,7 @@ tasks:
     cmd: foobar
   echo:
     cmd: echo
+  interpolate:
+    cmd:
+      foo=value_from_task
+      echo $(echo envvar from subshell is $foo)

--- a/examples/shell/package_test.go
+++ b/examples/shell/package_test.go
@@ -16,6 +16,7 @@ var tests = []TestTable{
 	{Arg: `-v=1 echo`, Out: `(Running){0}`},
 	{Arg: `-v=1 echo`, Out: `(echo)`},
 	{Arg: `subshell`, Out: `subshell works`},
+	{Arg: `interpolate`, Out: `envvar from subshell is value_from_task`},
 }
 
 func Test(t *testing.T) {


### PR DESCRIPTION
- [x] References issue #98 
- [x] Add failing/reproduceable tests
- [x] Fix tests

`myke` consciously stays away from any manual interpolation, and such feature requests were preemptively removed/closed, so no magic involved in myke here. This seems to be related to how golang does `exec.Command`, maybe it doesn't properly quote/sanitize the arguments parameter.

In any case, this has to be fixed with a workaround in myke, because scripts can have such $ subshells, and it has to work irrespective of golang exec

cc @markusjevringgoeuro 