### PR TITLE
Allow templated env variables and pass CLI args to subsequent myke calls

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -14,7 +14,7 @@ func Template(opts *mykeOpts) error {
 		return errors.Wrap(err, "error rendering template")
 	}
 
-	rendered, err := core.RenderTemplate(string(bytes), core.OsEnv(), map[string]string{})
+	rendered, err := core.RenderTemplate(string(bytes), core.OsEnv())
 	if err != nil {
 		return errors.Wrap(err, "error rendering template")
 	}

--- a/core/template.go
+++ b/core/template.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"github.com/Masterminds/sprig"
 	"text/template"
+	"github.com/pkg/errors"
 )
 
-// RenderTemplate renders the given template with env/args map
-func RenderTemplate(tmpl string, env map[string]string, args map[string]string) (string, error) {
+// RenderTemplate renders the given template with params map
+func RenderTemplate(tmpl string, params map[string]string) (string, error) {
 	w := new(bytes.Buffer)
-	params := union(env, args)
 	funcs := template.FuncMap{
 		"required": templateRequired,
 	}
@@ -26,6 +26,45 @@ func RenderTemplate(tmpl string, env map[string]string, args map[string]string) 
 
 	err = tpl.Execute(w, params)
 	return w.String(), err
+}
+
+// RenderParams renders the given parameters recursively
+func RenderParams(params map[string]string) (map[string]string, error) {
+	renderedParams := make(map[string]string)
+
+	for key, value := range params {
+		renderedValue, err := renderParamValue(value, params)
+		if err != nil {
+			return nil, err
+		}
+		renderedParams[key] = renderedValue
+	}
+
+	return renderedParams, nil
+}
+
+func renderParamValue(value string, params map[string]string) (string, error) {
+	return renderParamValueRecursively(value, params, 0)
+}
+
+func renderParamValueRecursively(value string, params map[string]string, recursionLevel int) (string,
+	error) {
+	const maxRecursionCount = 5
+
+	if recursionLevel >= maxRecursionCount {
+		return "", errors.Errorf("Cannot render template '%v'. Max recursion level (%v) exceeded.", value, maxRecursionCount)
+	}
+
+	renderedValue, err := RenderTemplate(value, params)
+	if err != nil {
+		return "", err
+	}
+
+	if renderedValue == value {
+		return renderedValue, nil
+	}
+
+	return renderParamValueRecursively(renderedValue, params, recursionLevel+1)
 }
 
 func templateRequired(s string) (interface{}, error) {

--- a/examples/env/myke.yml
+++ b/examples/env/myke.yml
@@ -18,6 +18,8 @@ env:
 
   # PATH is always prepended, not overwritten
   PATH: path_from_yml
+  KEY_TEMPLATE: template {{ .KEY_YML }}
+  KEY_TEMPLATE_RECURSIVE: recursive {{ .KEY_TEMPLATE }}
 tasks:
   yml:
     cmd: echo envvar from yml is $KEY_YML
@@ -31,3 +33,9 @@ tasks:
     cmd: echo envvar from test.env.local is $KEY_ENVFILE_LOCAL
   path:
     cmd: echo PATH is $PATH
+  key_template:
+    cmd: echo Templated key is $KEY_TEMPLATE
+  key_template_recursive:
+    cmd: echo Templated key is $KEY_TEMPLATE_RECURSIVE
+  pass_args_as_env_variable:
+    cmd: echo "Args $CLI_ARGS"

--- a/examples/env/package_test.go
+++ b/examples/env/package_test.go
@@ -12,6 +12,9 @@ var tests = []TestTable{
 	{Arg: `file_custom`, Out: `envvar from test.env is value_from_test.env`},
 	{Arg: `file_custom_local`, Out: `envvar from test.env.local is value_from_test.env.local`},
 	{Arg: `path`, Out: `PATH is [^$PLS$]+env$PS$path_from_myke.env.local$PLS$[^$PLS$]+env$PS$path_from_myke.env$PLS$[^$PLS$]+env$PS$path_from_test.env.local$PLS$[^$PLS$]+env$PS$path_from_test.env$PLS$[^$PLS$]+env$PS$path_from_yml$PLS$[^$PLS$]+env$PS$bin`},
+	{Arg: `key_template`, Out: `Templated key is template value_from_yml`},
+	{Arg: `pass_args_as_env_variable --CLI_ARGS=Test`, Out: "Args Test"},
+	{Arg: `key_template_recursive`, Out: `Templated key is recursive template value_from_yml`},
 }
 
 func Test(t *testing.T) {

--- a/examples/package_test.go
+++ b/examples/package_test.go
@@ -7,7 +7,7 @@ import (
 
 var tests = []TestTable{
 	{Arg: ``, Out: `(?m)^\s*PROJECT\s*\|\s*TAGS\s*\|\s*TASKS\s*$`},
-	{Arg: ``, Out: `(?m)^\s*env\s*\|\s*\|\s*file_custom, file_custom_local, file_default, file_default_local, path, yml\s*$`},
+	{Arg: ``, Out: `(?m)^\s*env\s*\|\s*\|\s*file_custom, file_custom_local, file_default, file_default_local, key_template, key_template_recursive, pass_args_as_env_variable, path, yml\s*$`},
 	{Arg: ``, Out: `(?m)^\s*hooks\s*\|\s*\|\s*after, before, error\s*$`},
 	{Arg: ``, Out: `(?m)^\s*mixin\s*\|\s*\|\s*path, task1, task2, task3\s*$`},
 	{Arg: ``, Out: `(?m)^\s*retry\s*\|\s*\|\s*retry\s*$`},


### PR DESCRIPTION
- Templates within environment variables will be resolved. Templates will be resolved recursively (max. recursion count is set to 5 right now).  Example:
```yaml
project: sample
env:
  VERSION: 1.2.3
  DISPLAY_NAME: Test-{{ .VERSION }}
  DESCRIPTION: Description {{ .DISPLAY_NAME }}
```
- CLI arguments will be passed as environment variables when calling other myke tasks within a task exection. Example:
```sh
myke build --PROXY=http://sample.org:3128
```

```yaml
project: sample
tasks:
  build:
    cmd: |
      myke download # Pass CLI argument PROXY as env variable to next myke call
      ./gradlew build
  download:
    cmd: curl --proxy $PROXY -sLo file.tgz http://sample.org/file.tgz
```